### PR TITLE
Add Discord links to navbar and footer

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -121,6 +121,11 @@ const config: Config = {
           position: 'left',
         },
         {
+          href: 'https://discord.com/invite/SRaRFcQ7Yw',
+          label: 'Discord',
+          position: 'right',
+        },
+        {
           href: 'https://github.com/thatapicompany/overture-maps-api',
           label: 'API GitHub',
           position: 'right',
@@ -142,6 +147,10 @@ const config: Config = {
         {
           title: 'Community',
           items: [
+            {
+              label: 'Discord',
+              href: 'https://discord.com/invite/SRaRFcQ7Yw',
+            },
             {
               label: 'Overture Maps Foundation',
               href: 'https://overturemaps.org/',


### PR DESCRIPTION
## Summary
- add Discord link to the navbar before API GitHub
- add Discord link under Community in the footer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: File name differs only in casing)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899d3021120832683b082194f36d37f