### PR TITLE
Add privacy policy page and footer link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -187,6 +187,15 @@ const config: Config = {
             },
           ],
         },
+        {
+          title: 'Legal',
+          items: [
+            {
+              label: 'Privacy Policy',
+              to: '/privacy-policy',
+            },
+          ],
+        },
       ],
       //copyright: `Copyright © ${new Date().getFullYear()} My Project, Inc. Built with Docusaurus.`,
     },

--- a/src/pages/privacy-policy.md
+++ b/src/pages/privacy-policy.md
@@ -45,7 +45,7 @@ title: Privacy Policy
 ## Your rights
 - You may request a copy of your data.
 - You may ask us to delete your data.
-- Contact us at TODO: contact email.
+- Contact us at aden@thatapicompany.com
 
 ## Changes
 - We may update this policy.

--- a/src/pages/privacy-policy.md
+++ b/src/pages/privacy-policy.md
@@ -1,0 +1,54 @@
+---
+title: Privacy Policy
+---
+
+# Privacy Policy
+
+:::info Summary at a glance
+- We collect minimal information to run the API.
+- We do not store latitude or longitude from requests.
+- We keep anonymized Place, Brand, and Category lookups to improve datasets.
+- Infrastructure and hosting use GCP, Cloudflare, and Vercel.
+- Logs are retained for 400 days.
+- Google Analytics helps us understand which parts of the site and docs need improvement.
+- You can request access or deletion of your data.
+- We keep the service secure.
+:::
+
+## Who we are
+- We operate the Overture Maps API.
+- We design it with privacy first.
+
+## Information we collect
+- Basic request logs.
+- No latitude or longitude from user queries.
+- Anonymized Place, Brand, and Category lookup data to guide dataset improvements.
+
+## How we use information
+- To provide the API.
+- To debug and improve the service.
+- Google Analytics on the main website to understand which sections need improvement.
+- Analyze anonymized Place, Brand, and Category lookups to focus improvements and new datasets.
+
+## Data retention
+- We keep logs only as long as needed to run the API.
+- Logs are kept for 400 days and then deleted.
+
+## Data sharing
+- We do not sell personal data.
+- We share data only with service providers.
+- GCP for infrastructure and hosting.
+- Cloudflare for content delivery and security.
+- Vercel for website deployment.
+- We do not share API usage data with service providers.
+
+## Your rights
+- You may request a copy of your data.
+- You may ask us to delete your data.
+- Contact us at TODO: contact email.
+
+## Changes
+- We may update this policy.
+- We will post any changes on this page.
+
+This Privacy Policy is provided for general information and is not legal advice.


### PR DESCRIPTION
## Summary
- add dedicated privacy policy page with summary box and full provider, analytics, and retention details
- expose new policy via Legal section in footer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a14498a35083269309e0269d3092fa